### PR TITLE
Add new entities for clean count, true detect, and clean preference

### DIFF
--- a/custom_components/deebot/number.py
+++ b/custom_components/deebot/number.py
@@ -1,6 +1,6 @@
 """Number module."""
-from deebot_client.commands import SetVolume
-from deebot_client.events import VolumeEvent
+from deebot_client.commands import SetVolume, SetCleanCount
+from deebot_client.events import VolumeEvent, CleanCountEvent
 from deebot_client.events.event_bus import EventListener
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -25,6 +25,7 @@ async def async_setup_entry(
     new_devices = []
     for vacbot in hub.vacuum_bots:
         new_devices.append(VolumeEntity(vacbot))
+        new_devices.append(CleanCountEntity(vacbot))
 
     if new_devices:
         async_add_entities(new_devices)
@@ -81,3 +82,36 @@ class VolumeEntity(DeebotEntity, NumberEntity):  # type: ignore
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self._vacuum_bot.execute_command(SetVolume(int(value)))
+
+
+class CleanCountEntity(DeebotEntity, NumberEntity):  # type: ignore
+    """Clean count number entity."""
+
+    entity_description = NumberEntityDescription(
+        key="clean_count",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    _attr_native_min_value = 1
+    _attr_native_max_value = 4
+    _attr_native_step = 1.0
+    _attr_native_value: float | None = None
+    _attr_icon = "mdi:counter"
+
+    async def async_added_to_hass(self) -> None:
+        """Set up the event listeners now that hass is ready."""
+        await super().async_added_to_hass()
+
+        async def on_clean_count(event: CleanCountEvent) -> None:
+            self._attr_native_value = event.count
+            self.async_write_ha_state()
+
+        listener: EventListener = self._vacuum_bot.events.subscribe(
+            CleanCountEvent, on_clean_count
+        )
+        self.async_on_remove(listener.unsubscribe)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        await self._vacuum_bot.execute_command(SetCleanCount(int(value)))

--- a/custom_components/deebot/number.py
+++ b/custom_components/deebot/number.py
@@ -1,6 +1,6 @@
 """Number module."""
-from deebot_client.commands import SetVolume, SetCleanCount
-from deebot_client.events import VolumeEvent, CleanCountEvent
+from deebot_client.commands import SetCleanCount, SetVolume
+from deebot_client.events import CleanCountEvent, VolumeEvent
 from deebot_client.events.event_bus import EventListener
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/deebot/switch.py
+++ b/custom_components/deebot/switch.py
@@ -5,14 +5,18 @@ from typing import Any
 from deebot_client.commands import (
     SetAdvancedMode,
     SetCarpetAutoFanBoost,
+    SetCleanPreference,
     SetContinuousCleaning,
+    SetTrueDetect,
 )
 from deebot_client.commands.common import SetEnableCommand
 from deebot_client.events import (
     AdvancedModeEvent,
     CarpetAutoFanBoostEvent,
+    CleanPreferenceEvent,
     ContinuousCleaningEvent,
     EnableEvent,
+    TrueDetectEvent,
 )
 from deebot_client.events.event_bus import EventListener
 from deebot_client.vacuum_bot import VacuumBot
@@ -73,6 +77,28 @@ async def async_setup_entry(
                     ),
                     CarpetAutoFanBoostEvent,
                     SetCarpetAutoFanBoost,
+                ),
+                DeebotSwitchEntity(
+                    vacbot,
+                    SwitchEntityDescription(
+                        key="clean_preference",
+                        entity_registry_enabled_default=False,
+                        entity_category=EntityCategory.CONFIG,
+                        icon="mdi:broom",
+                    ),
+                    CleanPreferenceEvent,
+                    SetCleanPreference,
+                ),
+                DeebotSwitchEntity(
+                    vacbot,
+                    SwitchEntityDescription(
+                        key="true_detect",
+                        entity_registry_enabled_default=False,
+                        entity_category=EntityCategory.CONFIG,
+                        icon="mdi:laser-pointer",
+                    ),
+                    TrueDetectEvent,
+                    SetTrueDetect,
                 ),
             ]
         )


### PR DESCRIPTION
As discussed in #254. Closes #254 

Depends on changes in https://github.com/DeebotUniverse/client.py/pull/163 to be merged & released.

Adds 3 new entities:


- TrueDetect switch: Enable/Disable "True Detect Obstacle Avoidance" technology
- Clean Count: Set the number of times to clean the area. From testing any integer works - it's possible to clean areas more than twice!
- Clean Preference switch: Enable/Disable "Auto cleaning" mode - I named the switch after the API name, but happy to change this to "Cleaning Preference" to align more closely with the terminology used in the app.

<img width="343" alt="image" src="https://user-images.githubusercontent.com/1289759/194534669-c41c3896-9d9d-4d75-8dc1-51311e2b315d.png">
