### PR TITLE
add possibility to translate name and attributes

### DIFF
--- a/custom_components/deebot/binary_sensor.py
+++ b/custom_components/deebot/binary_sensor.py
@@ -40,6 +40,7 @@ class DeebotMopAttachedBinarySensor(DeebotEntity, BinarySensorEntity):  # type: 
 
     entity_description = BinarySensorEntityDescription(
         key="mop_attached",
+        translation_key="mop_attached",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     )

--- a/custom_components/deebot/button.py
+++ b/custom_components/deebot/button.py
@@ -39,8 +39,10 @@ class DeebotResetLifeSpanButtonEntity(DeebotEntity, ButtonEntity):  # type: igno
     """Deebot reset life span button entity."""
 
     def __init__(self, vacuum_bot: VacuumBot, component: LifeSpan):
+        key = f"life_span_{component.name.lower()}_reset"
         entity_description = ButtonEntityDescription(
-            key=f"life_span_{component.name.lower()}_reset",
+            key=key,
+            translation_key=key,
             icon="mdi:air-filter" if component == LifeSpan.FILTER else "mdi:broom",
             entity_registry_enabled_default=True,  # Can be enabled as they don't poll data
             entity_category=EntityCategory.CONFIG,
@@ -58,6 +60,7 @@ class DeebotRelocateButtonEntity(DeebotEntity, ButtonEntity):  # type: ignore
 
     entity_description = ButtonEntityDescription(
         key="relocate",
+        translation_key="relocate",
         icon="mdi:map-marker-question",
         entity_registry_enabled_default=True,  # Can be enabled as they don't poll data
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/deebot/camera.py
+++ b/custom_components/deebot/camera.py
@@ -42,7 +42,9 @@ class DeeboLiveCamera(DeebotEntity, Camera):  # type: ignore
     """Deebot Live Camera."""
 
     entity_description = EntityDescription(
-        key="live_map", entity_registry_enabled_default=False
+        key="live_map",
+        translation_key="live_map",
+        entity_registry_enabled_default=False,
     )
 
     _attr_should_poll = True

--- a/custom_components/deebot/entity.py
+++ b/custom_components/deebot/entity.py
@@ -2,12 +2,7 @@
 from deebot_client.events import AvailabilityEvent
 from deebot_client.events.event_bus import EventListener
 from deebot_client.vacuum_bot import VacuumBot
-from homeassistant.helpers.entity import (
-    UNDEFINED,
-    DeviceInfo,
-    Entity,
-    EntityDescription,
-)
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 
 from . import DOMAIN
 
@@ -40,10 +35,6 @@ class DeebotEntity(Entity):  # type: ignore # lgtm [py/missing-equals]
 
         if self.entity_description.key:
             self._attr_unique_id += f"_{self.entity_description.key}"
-
-        if self.entity_description.name == UNDEFINED:
-            # Name not provided... get it from the key
-            self._attr_name = self.entity_description.key.replace("_", " ").capitalize()
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/deebot/image.py
+++ b/custom_components/deebot/image.py
@@ -40,8 +40,8 @@ class DeebotMap(DeebotEntity, ImageEntity):  # type: ignore
     """Deebot map."""
 
     entity_description = EntityDescription(
-        key="live_map",
-        translation_key="live_map",
+        key="map",
+        translation_key="map",
         entity_registry_enabled_default=False,
     )
 

--- a/custom_components/deebot/number.py
+++ b/custom_components/deebot/number.py
@@ -36,6 +36,7 @@ class VolumeEntity(DeebotEntity, NumberEntity):  # type: ignore
 
     entity_description = NumberEntityDescription(
         key="volume",
+        translation_key="volume",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.CONFIG,
     )
@@ -89,6 +90,7 @@ class CleanCountEntity(DeebotEntity, NumberEntity):  # type: ignore
 
     entity_description = NumberEntityDescription(
         key="clean_count",
+        translation_key="clean_count",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.CONFIG,
     )

--- a/custom_components/deebot/select.py
+++ b/custom_components/deebot/select.py
@@ -38,6 +38,7 @@ class WaterInfoSelect(DeebotEntity, SelectEntity):  # type: ignore
 
     entity_description = SelectEntityDescription(
         key="water_amount",
+        translation_key="water_amount",
         entity_registry_enabled_default=False,
         icon="mdi:water",
         entity_category=EntityCategory.CONFIG,

--- a/custom_components/deebot/sensor.py
+++ b/custom_components/deebot/sensor.py
@@ -65,6 +65,7 @@ async def async_setup_entry(
                     vacbot,
                     SensorEntityDescription(
                         key="stats_area",
+                        translation_key="stats_area",
                         icon="mdi:floor-plan",
                         native_unit_of_measurement=AREA_SQUARE_METERS,
                         entity_registry_enabled_default=False,
@@ -76,6 +77,7 @@ async def async_setup_entry(
                     vacbot,
                     SensorEntityDescription(
                         key="stats_time",
+                        translation_key="stats_time",
                         icon="mdi:timer-outline",
                         native_unit_of_measurement=TIME_MINUTES,
                         entity_registry_enabled_default=False,
@@ -87,6 +89,7 @@ async def async_setup_entry(
                     vacbot,
                     SensorEntityDescription(
                         key="stats_type",
+                        translation_key="stats_type",
                         icon="mdi:cog",
                         entity_registry_enabled_default=False,
                     ),
@@ -98,6 +101,7 @@ async def async_setup_entry(
                     vacbot,
                     SensorEntityDescription(
                         key="stats_total_area",
+                        translation_key="stats_total_area",
                         icon="mdi:floor-plan",
                         native_unit_of_measurement=AREA_SQUARE_METERS,
                         entity_registry_enabled_default=False,
@@ -110,6 +114,7 @@ async def async_setup_entry(
                     vacbot,
                     SensorEntityDescription(
                         key="stats_total_time",
+                        translation_key="stats_total_time",
                         icon="mdi:timer-outline",
                         native_unit_of_measurement=TIME_HOURS,
                         entity_registry_enabled_default=False,
@@ -122,6 +127,7 @@ async def async_setup_entry(
                     vacbot,
                     SensorEntityDescription(
                         key="stats_total_cleanings",
+                        translation_key="stats_total_cleanings",
                         icon="mdi:counter",
                         entity_registry_enabled_default=False,
                         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -133,6 +139,7 @@ async def async_setup_entry(
                     vacbot,
                     SensorEntityDescription(
                         key=ATTR_BATTERY_LEVEL,
+                        translation_key=ATTR_BATTERY_LEVEL,
                         native_unit_of_measurement=PERCENTAGE,
                         device_class=SensorDeviceClass.BATTERY,
                         entity_category=EntityCategory.DIAGNOSTIC,
@@ -187,6 +194,7 @@ class LastErrorSensor(DeebotEntity, SensorEntity):  # type: ignore
     _always_available = True
     entity_description = SensorEntityDescription(
         key=LAST_ERROR,
+        translation_key=LAST_ERROR,
         icon="mdi:alert-circle",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -212,8 +220,10 @@ class LifeSpanSensor(DeebotEntity, SensorEntity):  # type: ignore
 
     def __init__(self, vacuum_bot: VacuumBot, component: LifeSpan):
         """Initialize the Sensor."""
+        key = f"life_span_{component.name.lower()}"
         entity_description = SensorEntityDescription(
-            key=f"life_span_{component.name.lower()}",
+            key=key,
+            translation_key=key,
             icon="mdi:air-filter" if component == LifeSpan.FILTER else "mdi:broom",
             entity_registry_enabled_default=False,
             native_unit_of_measurement="%",
@@ -246,6 +256,7 @@ class LastCleaningJobSensor(DeebotEntity, SensorEntity):  # type: ignore
     _always_available = True
     entity_description = SensorEntityDescription(
         key="last_cleaning",
+        translation_key="last_cleaning",
         icon="mdi:history",
         entity_registry_enabled_default=False,
     )

--- a/custom_components/deebot/switch.py
+++ b/custom_components/deebot/switch.py
@@ -49,6 +49,7 @@ async def async_setup_entry(
                     vacbot,
                     SwitchEntityDescription(
                         key="advanced_mode",
+                        translation_key="advanced_mode",
                         entity_registry_enabled_default=False,
                         entity_category=EntityCategory.CONFIG,
                         icon="mdi:tune",
@@ -60,6 +61,7 @@ async def async_setup_entry(
                     vacbot,
                     SwitchEntityDescription(
                         key="continuous_cleaning",
+                        translation_key="continuous_cleaning",
                         entity_registry_enabled_default=False,
                         entity_category=EntityCategory.CONFIG,
                         icon="mdi:refresh-auto",
@@ -71,6 +73,7 @@ async def async_setup_entry(
                     vacbot,
                     SwitchEntityDescription(
                         key="carpet_auto_fan_speed_boost",
+                        translation_key="carpet_auto_fan_speed_boost",
                         entity_registry_enabled_default=False,
                         entity_category=EntityCategory.CONFIG,
                         icon="mdi:fan-auto",
@@ -82,6 +85,7 @@ async def async_setup_entry(
                     vacbot,
                     SwitchEntityDescription(
                         key="clean_preference",
+                        translation_key="clean_preference",
                         entity_registry_enabled_default=False,
                         entity_category=EntityCategory.CONFIG,
                         icon="mdi:broom",
@@ -93,6 +97,7 @@ async def async_setup_entry(
                     vacbot,
                     SwitchEntityDescription(
                         key="true_detect",
+                        translation_key="true_detect",
                         entity_registry_enabled_default=False,
                         entity_category=EntityCategory.CONFIG,
                         icon="mdi:laser-pointer",

--- a/custom_components/deebot/translations/en.json
+++ b/custom_components/deebot/translations/en.json
@@ -19,7 +19,7 @@
           "devices": "Devices"
         },
         "data_description": {
-          "devices": "Please select all devices, which you want use in HA."
+          "devices": "Please select all devices, which you want to use in HA."
         }
       },
       "user": {
@@ -35,7 +35,127 @@
         }
       },
       "user_advanced": {
-        "description": "Please select \"Bumper\" ONLY if you have a working bumper instance already. Otherwise, select \"Cloud\" please."
+        "description": "Please select \"Bumper\" ONLY if you already have a working bumper instance. Otherwise, select \"Cloud\" please."
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "mop_attached": {
+        "name": "Mop attached"
+      }
+    },
+    "button": {
+      "life_span_brush_reset": {
+        "name": "Reset brush"
+      },
+      "life_span_filter_reset": {
+        "name": "Reset filter"
+      },
+      "life_span_side_brush_reset": {
+        "name": "Reset side brush"
+      },
+      "relocate": {
+        "name": "Relocate"
+      }
+    },
+    "camera": {
+      "live_map": {
+        "name": "Live map"
+      }
+    },
+    "number": {
+      "clean_count": {
+        "name": "Clean count"
+      },
+      "volume": {
+        "name": "Volume"
+      }
+    },
+    "select": {
+      "water_amount": {
+        "name": "Water amount",
+        "state": {
+          "high": "high",
+          "low": "low",
+          "medium": "medium",
+          "ultrahigh": "ultrahigh"
+        }
+      }
+    },
+    "sensor": {
+      "battery_level": {
+        "name": "Battery level"
+      },
+      "last_cleaning": {
+        "name": "Last cleaning"
+      },
+      "last_error": {
+        "name": "Last error"
+      },
+      "life_span_brush": {
+        "name": "Brush"
+      },
+      "life_span_filter": {
+        "name": "Filter"
+      },
+      "life_span_side_brush": {
+        "name": "Side brush"
+      },
+      "stats_area": {
+        "name": "Stats area"
+      },
+      "stats_time": {
+        "name": "Stats time"
+      },
+      "stats_total_area": {
+        "name": "Stats total area"
+      },
+      "stats_total_cleanings": {
+        "name": "Stats total cleanings"
+      },
+      "stats_total_time": {
+        "name": "Stats total time"
+      },
+      "stats_type": {
+        "name": "Stats type"
+      }
+    },
+    "switch": {
+      "advanced_mode": {
+        "name": "Advanced mode"
+      },
+      "carpet_auto_fan_speed_boost": {
+        "name": "Carpet auto fan speed boost"
+      },
+      "clean_preference": {
+        "name": "Clean preference"
+      },
+      "continuous_cleaning": {
+        "name": "Continuous cleaning"
+      },
+      "true_detect": {
+        "name": "True detect"
+      }
+    },
+    "vacuum": {
+      "bot": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "max": "Max",
+              "max+": "Max+",
+              "normal": "Normal",
+              "quiet": "Quiet"
+            }
+          },
+          "last_error": {
+            "name": "Last error"
+          },
+          "rooms": {
+            "name": "Rooms"
+          }
+        }
       }
     }
   },
@@ -56,7 +176,7 @@
           "devices": "Devices"
         },
         "data_description": {
-          "devices": "Please select all devices, which you want use in HA."
+          "devices": "Please select all devices, which you want to use in HA."
         }
       }
     }

--- a/custom_components/deebot/translations/en.json
+++ b/custom_components/deebot/translations/en.json
@@ -144,7 +144,7 @@
           "fan_speed": {
             "state": {
               "max": "Max",
-              "max+": "Max+",
+              "max_plus": "Max+",
               "normal": "Normal",
               "quiet": "Quiet"
             }

--- a/custom_components/deebot/translations/en.json
+++ b/custom_components/deebot/translations/en.json
@@ -59,9 +59,9 @@
         "name": "Relocate"
       }
     },
-    "camera": {
-      "live_map": {
-        "name": "Live map"
+    "image": {
+      "map": {
+        "name": "Map"
       }
     },
     "number": {

--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -107,7 +107,10 @@ class DeebotVacuum(DeebotEntity, StateVacuumEntity):  # type: ignore
 
     def __init__(self, vacuum_bot: VacuumBot):
         """Initialize the Deebot Vacuum."""
-        super().__init__(vacuum_bot, StateVacuumEntityDescription(key="", name=None))
+        super().__init__(
+            vacuum_bot,
+            StateVacuumEntityDescription(key="", translation_key="bot", name=None),
+        )
 
         self._battery: int | None = None
         self._fan_speed: str | None = None

--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -129,7 +129,7 @@ class DeebotVacuum(DeebotEntity, StateVacuumEntity):  # type: ignore
             self.async_write_ha_state()
 
         async def on_fan_speed(event: FanSpeedEvent) -> None:
-            self._attr_fan_speed = event.speed
+            self._attr_fan_speed = event.speed.display_name
             self.async_write_ha_state()
 
         async def on_report_stats(event: ReportStatsEvent) -> None:

--- a/translations.schema.json
+++ b/translations.schema.json
@@ -298,7 +298,7 @@
                             "max": {
                               "type": "string"
                             },
-                            "max+": {
+                            "max_plus": {
                               "type": "string"
                             },
                             "normal": {

--- a/translations.schema.json
+++ b/translations.schema.json
@@ -163,10 +163,10 @@
           },
           "type": "object"
         },
-        "camera": {
+        "image": {
           "additionalProperties": false,
           "properties": {
-            "live_map": {
+            "map": {
               "$ref": "#/definitions/translation_name"
             }
           },

--- a/translations.schema.json
+++ b/translations.schema.json
@@ -1,6 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "definitions": {
+    "translation_name": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
   "properties": {
     "config": {
       "additionalProperties": false,
@@ -115,6 +126,216 @@
                 }
               },
               "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "entity": {
+      "additionalProperties": false,
+      "properties": {
+        "binary_sensor": {
+          "additionalProperties": false,
+          "properties": {
+            "mop_attached": {
+              "$ref": "#/definitions/translation_name"
+            }
+          },
+          "type": "object"
+        },
+        "button": {
+          "additionalProperties": false,
+          "properties": {
+            "life_span_brush_reset": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "life_span_filter_reset": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "life_span_side_brush_reset": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "relocate": {
+              "$ref": "#/definitions/translation_name"
+            }
+          },
+          "type": "object"
+        },
+        "camera": {
+          "additionalProperties": false,
+          "properties": {
+            "live_map": {
+              "$ref": "#/definitions/translation_name"
+            }
+          },
+          "type": "object"
+        },
+        "number": {
+          "additionalProperties": false,
+          "properties": {
+            "clean_count": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "volume": {
+              "$ref": "#/definitions/translation_name"
+            }
+          },
+          "type": "object"
+        },
+        "select": {
+          "additionalProperties": false,
+          "properties": {
+            "water_amount": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "state": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "high": {
+                      "type": "string"
+                    },
+                    "low": {
+                      "type": "string"
+                    },
+                    "medium": {
+                      "type": "string"
+                    },
+                    "ultrahigh": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "sensor": {
+          "additionalProperties": false,
+          "properties": {
+            "battery_level": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "last_cleaning": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "last_error": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "life_span_brush": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "life_span_filter": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "life_span_side_brush": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "stats_area": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "stats_time": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "stats_total_area": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "stats_total_cleanings": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "stats_total_time": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "stats_type": {
+              "$ref": "#/definitions/translation_name"
+            }
+          },
+          "type": "object"
+        },
+        "switch": {
+          "additionalProperties": false,
+          "properties": {
+            "advanced_mode": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "carpet_auto_fan_speed_boost": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "clean_preference": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "continuous_cleaning": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "true_detect": {
+              "$ref": "#/definitions/translation_name"
+            }
+          },
+          "type": "object"
+        },
+        "vacuum": {
+          "additionalProperties": false,
+          "properties": {
+            "bot": {
+              "additionalProperties": false,
+              "properties": {
+                "state_attributes": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "fan_speed": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "state": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "max": {
+                              "type": "string"
+                            },
+                            "max+": {
+                              "type": "string"
+                            },
+                            "normal": {
+                              "type": "string"
+                            },
+                            "quiet": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "last_error": {
+                      "$ref": "#/definitions/translation_name"
+                    },
+                    "rooms": {
+                      "$ref": "#/definitions/translation_name"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "carpet_auto_fan_speed_boost": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "clean_preference": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "continuous_cleaning": {
+              "$ref": "#/definitions/translation_name"
+            },
+            "true_detect": {
+              "$ref": "#/definitions/translation_name"
             }
           },
           "type": "object"


### PR DESCRIPTION
**Breaking Change**:
Due the fact that the symbol `+` is not allowed to be included in a attribute state if you want to translate it. 
The fan speed level `max+` was renamed to `max_plus`