### PR TITLE
Make service "refresh" translatable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   pull_request: ~
 
 env:
-  DEFAULT_PYTHON: "3.10"
+  DEFAULT_PYTHON: "3.11"
 
 jobs:
   validate-hacs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v3.8.0
     hooks:
       - id: pyupgrade
-        args: [--py310-plus]
+        args: [--py311-plus]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/custom_components/deebot/__init__.py
+++ b/custom_components/deebot/__init__.py
@@ -1,9 +1,9 @@
 """Support for Deebot Vaccums."""
 import sys
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 11):
     raise RuntimeError(
-        f"This component requires at least python 3.10! You are running {sys.version}"
+        f"This component requires at least python 3.11! You are running {sys.version}"
     )
 
 # pylint: disable=wrong-import-position

--- a/custom_components/deebot/const.py
+++ b/custom_components/deebot/const.py
@@ -75,17 +75,17 @@ LAST_ERROR = "last_error"
 
 
 REFRESH_STR_TO_EVENT_DTO: Mapping[str, type[Event]] = {
-    "Battery": BatteryEvent,
-    "Clean logs": CleanLogEvent,
-    "Error": ErrorEvent,
-    "Fan speed": FanSpeedEvent,
-    "Life spans": LifeSpanEvent,
-    "Rooms": RoomsEvent,
-    "Stats": StatsEvent,
-    "Status": StateEvent,
-    "Water": WaterInfoEvent,
+    "battery": BatteryEvent,
+    "clean_logs": CleanLogEvent,
+    "error": ErrorEvent,
+    "fan_speed": FanSpeedEvent,
+    "life_spans": LifeSpanEvent,
+    "rooms": RoomsEvent,
+    "stats": StatsEvent,
+    "status": StateEvent,
+    "water": WaterInfoEvent,
 }
-REFRESH_MAP = "Map"
+REFRESH_MAP = "map"
 
 EVENT_CLEANING_JOB = "deebot_cleaning_job"
 EVENT_CUSTOM_COMMAND = "deebot_custom_command"

--- a/custom_components/deebot/services.yaml
+++ b/custom_components/deebot/services.yaml
@@ -5,14 +5,14 @@ refresh:
       integration: deebot
       domain: vacuum
   fields:
-    part:
+    category:
       required: true
       advanced: false
       example: "status"
       default: "status"
       selector:
         select:
-          translation_key: "refresh_part"
+          translation_key: "refresh_category"
           options:
             - "battery"
             - "clean_logs"

--- a/custom_components/deebot/services.yaml
+++ b/custom_components/deebot/services.yaml
@@ -1,29 +1,26 @@
 # Must be kept in sync with vacuum.py
 refresh:
-  name: Manually refresh
-  description: Manually request a refresh
   target:
     entity:
       integration: deebot
       domain: vacuum
   fields:
     part:
-      name: Part
-      description: Which part should be refreshed?
       required: true
       advanced: false
-      example: "Status"
-      default: "Status"
+      example: "status"
+      default: "status"
       selector:
         select:
+          translation_key: "refresh_part"
           options:
-            - "Status"
-            - "Error"
-            - "Fan speed"
-            - "Clean logs"
-            - "Water"
-            - "Battery"
-            - "Stats"
-            - "Life spans"
-            - "Rooms"
-            - "Map"
+            - "battery"
+            - "clean_logs"
+            - "error"
+            - "fan_speed"
+            - "life_spans"
+            - "map"
+            - "rooms"
+            - "stats"
+            - "status"
+            - "water"

--- a/custom_components/deebot/translations/de.json
+++ b/custom_components/deebot/translations/de.json
@@ -57,5 +57,33 @@
         }
       }
     }
+  },
+  "selector": {
+    "refresh_category": {
+      "options": {
+        "battery": "Batterie",
+        "clean_logs": "Reinungsprotokoll",
+        "error": "Fehler",
+        "fan_speed": "Lüftergeschwindigkeit",
+        "life_spans": "Komponentenabnutzung",
+        "map": "Karte",
+        "rooms": "Räume",
+        "stats": "Statistik",
+        "status": "Status",
+        "water": "Wasser"
+      }
+    }
+  },
+  "services": {
+    "refresh": {
+      "description": "Manuelle Aktualisierung der selektierten Kategorie.",
+      "fields": {
+        "category": {
+          "description": "Was soll aktualisiert werden?",
+          "name": "Kategorie"
+        }
+      },
+      "name": "Manuelle Aktualisierung"
+    }
   }
 }

--- a/custom_components/deebot/translations/en.json
+++ b/custom_components/deebot/translations/en.json
@@ -180,5 +180,33 @@
         }
       }
     }
+  },
+  "selector": {
+    "refresh_part": {
+      "options": {
+        "battery": "Battery",
+        "clean_logs": "Clean logs",
+        "error": "Error",
+        "fan_speed": "Fan speed",
+        "life_spans": "Life spans",
+        "map": "Map",
+        "rooms": "Rooms",
+        "stats": "Stats",
+        "status": "Status",
+        "water": "Water"
+      }
+    }
+  },
+  "services": {
+    "refresh": {
+      "description": "Manually request a refresh for the selected part.",
+      "fields": {
+        "part": {
+          "description": "Which part should be refreshed?",
+          "name": "Part"
+        }
+      },
+      "name": "Manually refresh"
+    }
   }
 }

--- a/custom_components/deebot/translations/en.json
+++ b/custom_components/deebot/translations/en.json
@@ -182,7 +182,7 @@
     }
   },
   "selector": {
-    "refresh_part": {
+    "refresh_category": {
       "options": {
         "battery": "Battery",
         "clean_logs": "Clean logs",
@@ -199,11 +199,11 @@
   },
   "services": {
     "refresh": {
-      "description": "Manually request a refresh for the selected part.",
+      "description": "Manually request a refresh for the selected category.",
       "fields": {
-        "part": {
-          "description": "Which part should be refreshed?",
-          "name": "Part"
+        "category": {
+          "description": "Which category should be refreshed?",
+          "name": "Category"
         }
       },
       "name": "Manually refresh"

--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -34,6 +34,7 @@ from homeassistant.components.vacuum import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 
@@ -56,11 +57,13 @@ _LOGGER = logging.getLogger(__name__)
 # Must be kept in sync with services.yaml
 SERVICE_REFRESH = "refresh"
 SERVICE_REFRESH_PART = "part"
-SERVICE_REFRESH_SCHEMA = {
-    vol.Required(SERVICE_REFRESH_PART): vol.In(
-        [*REFRESH_STR_TO_EVENT_DTO.keys(), REFRESH_MAP]
-    )
-}
+SERVICE_REFRESH_SCHEMA = make_entity_service_schema(
+    {
+        vol.Required(SERVICE_REFRESH_PART): vol.In(
+            [*REFRESH_STR_TO_EVENT_DTO.keys(), REFRESH_MAP]
+        )
+    }
+)
 
 
 async def async_setup_entry(
@@ -83,7 +86,7 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_REFRESH,
         SERVICE_REFRESH_SCHEMA,
-        "_service_refresh",
+        "service_refresh",
     )
 
 
@@ -254,7 +257,7 @@ class DeebotVacuum(DeebotEntity, StateVacuumEntity):  # type: ignore
         else:
             await self._vacuum_bot.execute_command(CustomCommand(command, params))
 
-    async def _service_refresh(self, part: str) -> None:
+    async def service_refresh(self, part: str) -> None:
         """Service to manually refresh."""
         _LOGGER.debug("Manually refresh %s", part)
         event = REFRESH_STR_TO_EVENT_DTO.get(part, None)

--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -56,10 +56,10 @@ _LOGGER = logging.getLogger(__name__)
 
 # Must be kept in sync with services.yaml
 SERVICE_REFRESH = "refresh"
-SERVICE_REFRESH_PART = "part"
+SERVICE_REFRESH_CATEGORY = "category"
 SERVICE_REFRESH_SCHEMA = make_entity_service_schema(
     {
-        vol.Required(SERVICE_REFRESH_PART): vol.In(
+        vol.Required(SERVICE_REFRESH_CATEGORY): vol.In(
             [*REFRESH_STR_TO_EVENT_DTO.keys(), REFRESH_MAP]
         )
     }
@@ -257,13 +257,15 @@ class DeebotVacuum(DeebotEntity, StateVacuumEntity):  # type: ignore
         else:
             await self._vacuum_bot.execute_command(CustomCommand(command, params))
 
-    async def service_refresh(self, part: str) -> None:
+    async def service_refresh(self, category: str) -> None:
         """Service to manually refresh."""
-        _LOGGER.debug("Manually refresh %s", part)
-        event = REFRESH_STR_TO_EVENT_DTO.get(part, None)
+        _LOGGER.debug("Manually refresh %s", category)
+        event = REFRESH_STR_TO_EVENT_DTO.get(category, None)
         if event:
             self._vacuum_bot.events.request_refresh(event)
-        elif part == REFRESH_MAP:
+        elif category == REFRESH_MAP:
             self._vacuum_bot.map.refresh()
         else:
-            _LOGGER.warning('Service "refresh" called with unknown part: %s', part)
+            _LOGGER.warning(
+                'Service "refresh" called with unknown category: %s', category
+            )

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "filename": "deebot.zip",
-  "homeassistant": "2023.7.0b0",
+  "homeassistant": "2023.8.0b0",
   "name": "Deebot 4 Home Assistant",
   "render_readme": true,
   "zip_release": true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.11
 show_error_codes = true
 follow_imports = silent
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-target-version = ['py310']
+target-version = ['py311']
 safe = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #git+https://github.com/DeebotUniverse/client.py@main#deebot-client==2.1.0b0
 deebot-client==3.0.0b0
 
-homeassistant>=2023.7.0b0
+homeassistant>=2023.8.0b0
 mypy==1.4.1
 
 numpy>=1.21.2

--- a/translations.schema.json
+++ b/translations.schema.json
@@ -412,7 +412,7 @@
     "selector": {
       "additionalProperties": false,
       "properties": {
-        "refresh_part": {
+        "refresh_category": {
           "additionalProperties": false,
           "properties": {
             "options": {
@@ -469,7 +469,7 @@
             "fields": {
               "additionalProperties": false,
               "properties": {
-                "part": {
+                "category": {
                   "additionalProperties": false,
                   "properties": {
                     "description": {

--- a/translations.schema.json
+++ b/translations.schema.json
@@ -408,6 +408,90 @@
         }
       },
       "type": "object"
+    },
+    "selector": {
+      "additionalProperties": false,
+      "properties": {
+        "refresh_part": {
+          "additionalProperties": false,
+          "properties": {
+            "options": {
+              "additionalProperties": false,
+              "properties": {
+                "battery": {
+                  "type": "string"
+                },
+                "clean_logs": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "string"
+                },
+                "fan_speed": {
+                  "type": "string"
+                },
+                "life_spans": {
+                  "type": "string"
+                },
+                "map": {
+                  "type": "string"
+                },
+                "rooms": {
+                  "type": "string"
+                },
+                "stats": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "water": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "services": {
+      "additionalProperties": false,
+      "properties": {
+        "refresh": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "fields": {
+              "additionalProperties": false,
+              "properties": {
+                "part": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
     }
   },
   "type": "object"


### PR DESCRIPTION
**Breaking Change:**
- Renaming field `part` to `category`.
- All options are now lower case and blank spaces are replaced by an underscore for them to be translatable.